### PR TITLE
Bump down django version to LTS version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 beautifulsoup4==4.8.2
-django>=3.0.2<3.0.9
+django>=2.2.0<2.2.9


### PR DESCRIPTION
We should rather use Long Term Support version for
multitude of reasons, but probably most important reason
is many libraries/dependencies don't support Django 3.X.